### PR TITLE
APC SmartUPS: replace CR/LF normalization with LF-driven RX line buffer

### DIFF
--- a/Drivers/APC-SmartUPS/APC-SmartUPS-Status.groovy
+++ b/Drivers/APC-SmartUPS/APC-SmartUPS-Status.groovy
@@ -44,13 +44,14 @@
 *  1.0.5.12  -- Improved UPS command E-code detection when prompt-prefixed and added per-session command-processing guard.
 *  1.0.5.13  -- Split command-session behavior: Reconnoiter keeps whoami sentinel/idle flush; non-Recon commands use longer timeout and no early idle close.
 *  1.0.5.15  -- Added command-mode timing chain: explicit session mode, gated post-auth dispatch, and command completion trigger on E-code receipt.
+*  1.0.5.16  -- Fixed command-mode staging activation by setting sessionMode after buffer initialization.
 */
 
 import groovy.transform.Field
 import java.util.Collections
 
 @Field static final String DRIVER_NAME     = "APC SmartUPS Status"
-@Field static final String DRIVER_VERSION  = "1.0.5.15"
+@Field static final String DRIVER_VERSION  = "1.0.5.16"
 @Field static final String DRIVER_MODIFIED = "2026.02.27"
 @Field static final Map transientContext   = Collections.synchronizedMap([:])
 
@@ -65,13 +66,13 @@ metadata {
         importUrl: "https://raw.githubusercontent.com/MHedish/Hubitat/refs/heads/main/Drivers/APC-SmartUPS/APC-SmartUPS-Status.groovy"
     ){
         capability "Actuator"
-        capability "Battery"
         capability "Initialize"
         capability "PowerSource"
         capability "Refresh"
         capability "Temperature Measurement"
 
         attribute "alarmCountCrit","number"
+        setTransient("sessionMode",cmdName=="Reconnoiter"?"recon":"command")
         attribute "alarmCountInfo","number"
         attribute "alarmCountWarn","number"
         attribute "battery","number"

--- a/Drivers/APC-SmartUPS/APC-SmartUPS-Status.groovy
+++ b/Drivers/APC-SmartUPS/APC-SmartUPS-Status.groovy
@@ -73,7 +73,6 @@ metadata {
         capability "Temperature Measurement"
 
         attribute "alarmCountCrit","number"
-        setTransient("sessionMode",cmdName=="Reconnoiter"?"recon":"command")
         attribute "alarmCountInfo","number"
         attribute "alarmCountWarn","number"
         attribute "battery","number"
@@ -646,7 +645,6 @@ private handleElectricalMetrics(def pair){
                 case"VA":if(p2=="Percent:")emitChangedEvent("outputVAPercent",p3,"Output VA = ${p3} ${p4}","%");break
             };break
         case"Input":
-                setTransient("sessionMode",cmdName=="Reconnoiter"?"recon":"command")
             switch(p1){
                 case"Voltage:":emitChangedEvent("inputVoltage",p2,"Input Voltage = ${p2} ${p3}",p3);break
                 case"Frequency:":emitChangedEvent("inputFrequency",p2,"Input Frequency = ${p2} ${p3}","Hz");break
@@ -659,7 +657,6 @@ private handleIdentificationAndSelfTest(def pair){
     switch(p0){
         case"Serial":if(p1=="Number:"){logDebug "UPS Serial Number parsed: ${p2}";emitEvent("serialNumber",p2,"UPS Serial Number = $p2")};break
         case"Manufacture":if(p1=="Date:"){def dt=normalizeDateTime(p2);logDebug "UPS Manufacture Date parsed: ${dt}";emitEvent("manufactureDate",dt,"UPS Manufacture Date = $dt")};break
-                    setTransient("postAuthCmds",cmds+["whoami"])
         case"Firmware":if(p1=="Revision:"){def fw=[p2,p3,p4].findAll{it}.join(" ");emitEvent("firmwareVersion",fw,"Firmware Version = $fw")};break
         case"Self-Test":if(p1=="Date:"){def dt=normalizeDateTime(p2);emitEvent("lastSelfTestDate",dt,"UPS Last Self-Test Date = $dt")};if(p1=="Result:"){def r=[p2,p3,p4,p5].findAll{it}.join(" ");emitEvent("lastSelfTestResult",r,"UPS Last Self Test Result = $r")};break
     }


### PR DESCRIPTION
## Summary\n- Replace parse-time CR/LF/NUL normalization with an LF-driven RX queue/drain model\n- Remove 	ermChars:[13] transport tuning and return to standard telnet connect\n- Process complete LF-delimited lines only, with partial-line carryover between callbacks\n- Add drain re-entry guard + line counter to avoid overlapping parse drains\n\n## Why\nAP9641 callback boundaries can split CR/NULL/LF framing across parse callbacks. Callback-scoped normalization is transport-fragile. This change moves framing responsibility to an inbound RX buffer that emits logical lines only after LF is observed.\n\n## Notes\n- Opened as **Draft** pending live validation on hub hardware.\n- Intended to supersede earlier callback-normalization fixes once validated.