### PR TITLE
APC SmartUPS: baseline reset + stream normalizer (draft)

### DIFF
--- a/Drivers/APC-SmartUPS/APC-SmartUPS-Status.groovy
+++ b/Drivers/APC-SmartUPS/APC-SmartUPS-Status.groovy
@@ -797,14 +797,16 @@ private boolean telnetSend(List m,Integer ms){
     int throttleMs=(getTransient("sendThrottleMs")?:0) as int
     logDebug "telnetSend(): sending ${m.size()} messages with ${ms} ms delay"
     m.each{item->
-        int useDelay=ms
+        int postDelay=ms
         if(throttleRemaining>0&&throttleMs>0){
-            useDelay=Math.max(ms,throttleMs)
+            int preDelay=Math.max(ms,throttleMs)
             throttleRemaining--
             setTransient("sendThrottleRemaining",throttleRemaining)
-            logInfo "send throttle: applying ${useDelay}ms delay (${throttleRemaining} primed sends remaining)"
+            logInfo "send throttle: applying ${preDelay}ms pre-send delay (${throttleRemaining} primed sends remaining)"
+            pauseExecution(preDelay)
+            postDelay=0
         }
-        sendData("$item",useDelay)
+        sendData("$item",postDelay)
     }
     true
 }

--- a/Drivers/APC-SmartUPS/APC-SmartUPS-Status.groovy
+++ b/Drivers/APC-SmartUPS/APC-SmartUPS-Status.groovy
@@ -369,7 +369,6 @@ def initialize(){
     if(logEnable)logDebug("IP=$upsIP, Port=$upsPort, Username=$Username, Password=${Password?.replaceAll(/./, '*')}")else logInfo "IP=$upsIP, Port=$upsPort"
     if(upsIP&&upsPort&&Username&&Password){
         unschedule(autoDisableDebugLogging)
-        unschedule("runDeferredCommand")
         unschedule("processCommandQueue")
         if(logEnable)runIn(1800,autoDisableDebugLogging)
         updateUPSControlState(state.upsControlEnabled)
@@ -377,8 +376,6 @@ def initialize(){
         scheduleCheck(runTime as Integer,runOffset as Integer)
         clearTransient()
         clearCommandQueue();clearInFlightCommand()
-        atomicState.remove("deferredCommand")
-        atomicState.remove("deferredCmds")
         resetTransientState("initialize");updateConnectState("Disconnected");closeConnection();runInMillis(500,"refresh")
     }else logWarn"Cannot initialize. Preferences must be set."
 }

--- a/Drivers/APC-SmartUPS/APC-SmartUPS-Status.groovy
+++ b/Drivers/APC-SmartUPS/APC-SmartUPS-Status.groovy
@@ -735,7 +735,7 @@ private List<String> normalizeInboundLines(String msg){
     return lines
 }
 
-private parse(String msg){
+def parse(String msg){
     logTrace("parse: len=${msg?.length()?:0} status=${device.currentValue('connectStatus')?:'n/a'}")
     def lines=normalizeInboundLines(msg)
     if(!lines)return

--- a/Drivers/APC-SmartUPS/APC-SmartUPS-Status.groovy
+++ b/Drivers/APC-SmartUPS/APC-SmartUPS-Status.groovy
@@ -806,7 +806,7 @@ private boolean telnetSend(List m,Integer ms){
     logDebug "telnetSend(): sending ${m.size()} messages with ${ms} ms delay"
     m.each{item->
         int postDelay=ms
-        String payload="$item"
+        String payload="${item?:''}\r\n"
         if(throttleRemaining>0&&throttleMs>0){
             int preDelay=Math.max(ms,throttleMs)
             throttleRemaining--

--- a/Drivers/APC-SmartUPS/APC-SmartUPS-Status.groovy
+++ b/Drivers/APC-SmartUPS/APC-SmartUPS-Status.groovy
@@ -272,29 +272,29 @@ def installed(){logInfo "Installed";initialize()}
 def updated(){logInfo "Preferences updated";initialize()}
 
 private List<Map> getCommandQueue(){
-    def q=state.commandQueue
+    def q=getTransient("commandQueue")
     return (q instanceof List)?(q as List<Map>):[]
 }
 
 private void saveCommandQueue(List<Map> q){
-    state.commandQueue=q
+    setTransient("commandQueue",q)
 }
 
 private void clearCommandQueue(){
-    state.remove("commandQueue")
+    clearTransient("commandQueue")
 }
 
 private Map getInFlightCommand(){
-    def c=atomicState.commandInFlight
+    def c=getTransient("commandInFlight")
     return (c instanceof Map)?(c as Map):null
 }
 
 private void setInFlightCommand(String cmdName){
-    atomicState.commandInFlight=[cmd:cmdName,startedAt:now()]
+    setTransient("commandInFlight",[cmd:cmdName,startedAt:now()])
 }
 
 private void clearInFlightCommand(){
-    atomicState.remove("commandInFlight")
+    clearTransient("commandInFlight")
 }
 
 private void enqueueCommand(String cmdName,List cmds,String source="unknown"){

--- a/Drivers/APC-SmartUPS/APC-SmartUPS-Status.groovy
+++ b/Drivers/APC-SmartUPS/APC-SmartUPS-Status.groovy
@@ -158,7 +158,7 @@ preferences {
     input("autoShutdownHub","bool",title:"Shutdown Hubitat when UPS battery is low",description:"",defaultValue:true)
     input("upsTZOffset","number",title:"UPS Time Zone Offset (minutes)",description:"Offset UPS-reported time from hub (-720 to +840). Default=0 for same TZ",defaultValue:0,range:"-720..840")
     input("logEnable","bool",title:"Enable Debug Logging",description:"Auto-off after 30 minutes.",defaultValue:false)
-    input("logCallbackTrace","bool",title:"[Diagnostic] Log callback transport trace",description:"Temporary callback-level diagnostics for telnet transport behavior.",defaultValue:false)
+    input("logCallbackTrace","bool",title:"[Diagnostic] Log callback transport trace",description:"Advanced callback-level diagnostics for telnet transport behavior.",defaultValue:false)
     input("logEvents","bool",title:"Log All Events",description:"",defaultValue:false)
 }
 

--- a/Drivers/APC-SmartUPS/APC-SmartUPS-Status.groovy
+++ b/Drivers/APC-SmartUPS/APC-SmartUPS-Status.groovy
@@ -791,22 +791,33 @@ def parse(String msg){
    Telnet Data, Status & Close
    =============================== */
 private sendData(String m,Integer ms){logDebug "$m";def h=sendHubCommand(new hubitat.device.HubAction("$m",hubitat.device.Protocol.TELNET));pauseExecution(ms);return h}
+private void sendDataPaced(String payload,Integer charDelayMs){
+    if(payload==null)return
+    for(int i=0;i<payload.length();i++){
+        String ch=payload.substring(i,i+1)
+        sendData(ch,charDelayMs)
+    }
+}
 private telnetStatus(String s){def l=s?.toLowerCase()?:"";logTrace("status: ${s?:''}");if(l.contains("receive error: stream is closed")){def b=getTransient("telnetBuffer")?:[];logDebug"telnetStatus(): Stream closed, buffer has ${b.size()} lines";if(b&&b.size()>0&&device.currentValue("lastCommand")=="Reconnoiter"){def t=(b[-1]?.line?.toString()?:"");def tail=t.size()>100?t[-100..-1]:t;logDebug"telnetStatus(): Last buffer tail (up to 100 chars): ${tail}";logDebug"telnetStatus(): Stream closed with unprocessed buffer, forcing parse";processBufferedSession()};logDebug"telnetStatus(): connection reset after stream close"}else if(l.contains("send error")){logWarn"telnetStatus(): Telnet send error: ${s}"}else if(l.contains("closed")||l.contains("error")){logDebug"telnetStatus(): ${s}"}else logDebug"telnetStatus(): ${s}";closeConnection()}
 private boolean telnetSend(List m,Integer ms){
     int throttleRemaining=(getTransient("sendThrottleRemaining")?:0) as int
     int throttleMs=(getTransient("sendThrottleMs")?:0) as int
+    int charDelayMs=100
     logDebug "telnetSend(): sending ${m.size()} messages with ${ms} ms delay"
     m.each{item->
         int postDelay=ms
+        String payload="$item"
         if(throttleRemaining>0&&throttleMs>0){
             int preDelay=Math.max(ms,throttleMs)
             throttleRemaining--
             setTransient("sendThrottleRemaining",throttleRemaining)
-            logInfo "send throttle: applying ${preDelay}ms pre-send delay (${throttleRemaining} primed sends remaining)"
+            logInfo "send throttle: applying ${preDelay}ms pre-send delay + ${charDelayMs}ms char pacing (${throttleRemaining} primed sends remaining)"
             pauseExecution(preDelay)
+            sendDataPaced(payload,charDelayMs)
             postDelay=0
+        }else{
+            sendData(payload,postDelay)
         }
-        sendData("$item",postDelay)
     }
     true
 }

--- a/Drivers/APC-SmartUPS/APC-SmartUPS-Status.groovy
+++ b/Drivers/APC-SmartUPS/APC-SmartUPS-Status.groovy
@@ -174,7 +174,7 @@ private emitChangedEvent(String n,def v,String d=null,String u=null,boolean f=fa
 private updateConnectState(String newState){def old=device.currentValue("connectStatus");def last=getTransient("lastConnectState");if(old!=newState&&last!=newState){setTransient("lastConnectState",newState);emitChangedEvent("connectStatus",newState)}else{logDebug"updateConnectState(): no change (${old} → ${newState})"}}
 private updateCommandState(String newCmd){def old=atomicState.lastCommand;atomicState.lastCommand=newCmd;if(old!=newCmd)logDebug"lastCommand = ${newCmd}"}
 private def normalizeDateTime(String r){if(!r||r.trim()=="")return r;try{def m=r=~/^(\d{2})\/(\d{2})\/(\d{2})(?:\s+(\d{2}):(\d{2})(?::(\d{2}))?)?$/;if(m.matches()){def(mm,dd,yy,hh,mi,ss)=m[0][1..6];def y=(yy as int)<80?2000+(yy as int):1900+(yy as int);def f="${mm}/${dd}/${y}"+(hh?" ${hh}:${mi}:${ss?:'00'}":"");def d=Date.parse(hh?"MM/dd/yyyy HH:mm:ss":"MM/dd/yyyy",f);return hh?d.format("MM/dd/yyyy h:mm:ss a",location.timeZone):d.format("MM/dd/yyyy",location.timeZone)};for(fmt in["MM/dd/yyyy HH:mm:ss","MM/dd/yyyy h:mm:ss a","MM/dd/yyyy","yyyy-MM-dd","MMM dd yyyy HH:mm:ss"])try{def d=Date.parse(fmt,r);return(fmt.contains("HH")||fmt.contains("h:mm:ss"))?d.format("MM/dd/yyyy h:mm:ss a",location.timeZone):d.format("MM/dd/yyyy",location.timeZone)}catch(e){} }catch(e){};return r}
-private void initTelnetBuffer(){def b=getTransient("telnetBuffer");if(b instanceof List&&b.size()){def t;try{def p=b[-(Math.min(3,b.size()))..-1]*.line.findAll{it}.join(" | ");t=p[-(Math.min(80,p.size()))..-1]}catch(e){t="unavailable (${e.message})"};logDebug"initTelnetBuffer(): clearing leftover buffer (${b.size()} lines, preview='${t}')"};setTransient("telnetBuffer",[]);setTransient("rxCarry","");setTransient("sendThrottleRemaining",3);setTransient("sendThrottleMs",2000);setTransient("sessionStart",now());logDebug"initTelnetBuffer(): Session start at ${new Date(getTransient('sessionStart'))}"}
+private void initTelnetBuffer(){def b=getTransient("telnetBuffer");if(b instanceof List&&b.size()){def t;try{def p=b[-(Math.min(3,b.size()))..-1]*.line.findAll{it}.join(" | ");t=p[-(Math.min(80,p.size()))..-1]}catch(e){t="unavailable (${e.message})"};logDebug"initTelnetBuffer(): clearing leftover buffer (${b.size()} lines, preview='${t}')"};setTransient("telnetBuffer",[]);setTransient("rxCarry","");setTransient("sendThrottleRemaining",3);setTransient("sendThrottleMs",2000);setTransient("authStage",null);setTransient("postAuthCmds",null);setTransient("postAuthSent",false);setTransient("sessionStart",now());logDebug"initTelnetBuffer(): Session start at ${new Date(getTransient('sessionStart'))}"}
 private checkExternalUPSControlChange(){def c=device.currentValue("upsControlEnabled")as Boolean;def p=state.lastUpsControlEnabled as Boolean;if(p==null){state.lastUpsControlEnabled=c;return};if(c!=p){logInfo "UPS Control state changed externally (${p} → ${c})";state.lastUpsControlEnabled=c;updateUPSControlState(c);unschedule(autoDisableUPSControl);if(c)runIn(1800,"autoDisableUPSControl")else state.remove("controlDeviceName")}}
 
 /* ==================================
@@ -352,12 +352,14 @@ private void sendUPSCommand(String cmdName, List cmds){
         setTransient("sessionStart",now())
         logDebug"sendUPSCommand(): session start timestamp = ${getTransient('sessionStart')}"
         telnetClose();updateConnectState("Connecting");initTelnetBuffer()
-        state.pendingCmds=["$Username","$Password"]+cmds+["whoami"]
+        setTransient("authStage","await_user_prompt")
+        setTransient("postAuthCmds",cmds+["whoami"])
+        setTransient("postAuthSent",false)
+        state.remove("pendingCmds")
         logDebug"sendUPSCommand(): Opening transient Telnet connection to ${upsIP}:${upsPort}"
         safeTelnetConnect([ip:upsIP,port:upsPort.toInteger()])
         runIn(10,"checkSessionTimeout",[data:[cmd:cmdName]])
-        logDebug"sendUPSCommand(): queued ${state.pendingCmds.size()} Telnet lines for delayed send"
-        runInMillis(500,"delayedTelnetSend")
+        logDebug"sendUPSCommand(): auth-gated dispatch armed (${((getTransient('postAuthCmds')?:[]) as List).size()} post-auth commands queued)"
     }catch(e){
         logError"sendUPSCommand(${cmdName}): ${e.message}"
         emitChangedEvent("lastCommandResult","Failure")
@@ -410,6 +412,9 @@ private void resetTransientState(String origin, Boolean suppressWarn=false){
     clearTransient("rxCarry")
     clearTransient("sendThrottleRemaining")
     clearTransient("sendThrottleMs")
+    clearTransient("authStage")
+    clearTransient("postAuthCmds")
+    clearTransient("postAuthSent")
 }
 
 /* ===============================
@@ -759,6 +764,25 @@ def parse(String msg){
         def buf=getTransient("telnetBuffer")?:[]
         buf << [cmd: device.currentValue("lastCommand")?:"unknown",line: line]
         setTransient("telnetBuffer",buf)
+        def stage=(getTransient("authStage")?:"") as String
+        boolean postAuthSent=(getTransient("postAuthSent")?:false) as boolean
+        def queued=(getTransient("postAuthCmds")?:[]) as List
+        String lower=(line?:"").toLowerCase()
+        if(stage=="await_user_prompt"&&(lower.contains("user name")||lower.contains("user id")||lower.contains("userid")||lower.contains("username")||lower.contains("login"))){
+            logInfo"auth-chain: username prompt detected; sending username"
+            telnetSend(["$Username"],500)
+            setTransient("authStage","await_password_prompt")
+        }else if(stage=="await_password_prompt"&&lower.contains("password")){
+            logInfo"auth-chain: password prompt detected; sending password"
+            telnetSend(["$Password"],500)
+            setTransient("authStage","await_shell_prompt")
+        }else if(stage=="await_shell_prompt"&&!postAuthSent&&queued&&!queued.isEmpty()&&(lower.contains("apc>")||line.startsWith("E000:"))){
+            logInfo"auth-chain: shell prompt detected; sending ${queued.size()} queued command(s)"
+            telnetSend(queued,500)
+            setTransient("postAuthSent",true)
+            clearTransient("postAuthCmds")
+            setTransient("authStage","await_result")
+        }
         if(!state.authStarted){
             updateConnectState("Connected");logDebug "First Telnet data seen; session flagged as Connected"
             def cmd=device.currentValue("lastCommand")
@@ -833,7 +857,7 @@ private void closeConnection(){
         if(cs!="Disconnected"&&cs!="Disconnecting"){
             updateConnectState("Disconnected")
         }else logDebug"closeConnection(): connectStatus already ${cs}"
-        clearTransient("telnetBuffer");clearTransient("rxCarry");clearTransient("sendThrottleRemaining");clearTransient("sendThrottleMs");clearTransient("finalizing")
+        clearTransient("telnetBuffer");clearTransient("rxCarry");clearTransient("sendThrottleRemaining");clearTransient("sendThrottleMs");clearTransient("authStage");clearTransient("postAuthCmds");clearTransient("postAuthSent");clearTransient("finalizing")
         logDebug"closeConnection(): cleanup complete"
     }
 }

--- a/Drivers/APC-SmartUPS/APC-SmartUPS-Status.groovy
+++ b/Drivers/APC-SmartUPS/APC-SmartUPS-Status.groovy
@@ -35,13 +35,15 @@
 *  1.0.4.2   -- Deferred retry hardening/noise cleanup: dispatch deferred retries through runDeferredCommand payload replay, unschedule stale deferred timers before
 *               requeue/execute, and treat empty deferred payload callback as debug no-op.
 *  1.0.4.3   -- Increased Reconnoiter session watchdog window to 15s (commands remain 10s) to account for startup pacing under slower APC/NMC response conditions.
+*  1.0.4.4   -- Arbiter stability pass: restored queue/in-flight persistence to state and added session-token guards to suppress duplicate processing/finalization.
 */
 
 import groovy.transform.Field
 import java.util.Collections
+import java.util.UUID
 
 @Field static final String DRIVER_NAME     = "APC SmartUPS Status"
-@Field static final String DRIVER_VERSION  = "1.0.4.3"
+@Field static final String DRIVER_VERSION  = "1.0.4.4"
 @Field static final String DRIVER_MODIFIED = "2026.02.28"
 @Field static final Map transientContext   = Collections.synchronizedMap([:])
 
@@ -272,29 +274,33 @@ def installed(){logInfo "Installed";initialize()}
 def updated(){logInfo "Preferences updated";initialize()}
 
 private List<Map> getCommandQueue(){
-    def q=getTransient("commandQueue")
+    def q=state.commandQueue
     return (q instanceof List)?(q as List<Map>):[]
 }
 
 private void saveCommandQueue(List<Map> q){
-    setTransient("commandQueue",q)
+    state.commandQueue=q
 }
 
 private void clearCommandQueue(){
-    clearTransient("commandQueue")
+    state.remove("commandQueue")
 }
 
 private Map getInFlightCommand(){
-    def c=getTransient("commandInFlight")
+    def c=state.commandInFlight
     return (c instanceof Map)?(c as Map):null
 }
 
-private void setInFlightCommand(String cmdName){
-    setTransient("commandInFlight",[cmd:cmdName,startedAt:now()])
+private String newSessionToken(){
+    return UUID.randomUUID().toString()
+}
+
+private void setInFlightCommand(String cmdName,String token){
+    state.commandInFlight=[cmd:cmdName,startedAt:now(),token:token]
 }
 
 private void clearInFlightCommand(){
-    clearTransient("commandInFlight")
+    state.remove("commandInFlight")
 }
 
 private void enqueueCommand(String cmdName,List cmds,String source="unknown"){
@@ -365,10 +371,14 @@ def processCommandQueue(){
 }
 
 private void startCommandSession(String cmdName,List cmds){
-    setInFlightCommand(cmdName)
+    String token=newSessionToken()
+    setInFlightCommand(cmdName,token)
     updateCommandState(cmdName);updateConnectState("Initializing")
     emitChangedEvent("lastCommandResult","Pending","${cmdName} queued for execution");logInfo"Executing UPS command: ${cmdName}"
     try{
+        setTransient("sessionToken",token)
+        clearTransient("sessionProcessedToken")
+        clearTransient("sessionFinalizedToken")
         setTransient("currentCommand",cmdName)
         setTransient("sessionStart",now())
         logDebug"sendUPSCommand(): session start timestamp = ${getTransient('sessionStart')}"
@@ -377,7 +387,7 @@ private void startCommandSession(String cmdName,List cmds){
         logDebug"sendUPSCommand(): Opening transient Telnet connection to ${upsIP}:${upsPort}"
         safeTelnetConnect([ip:upsIP,port:upsPort.toInteger()])
         Integer timeoutSec=(cmdName=="Reconnoiter")?15:10
-        runIn(timeoutSec,"checkSessionTimeout",[data:[cmd:cmdName,timeoutMs:(timeoutSec*1000)]])
+        runIn(timeoutSec,"checkSessionTimeout",[data:[cmd:cmdName,token:token,timeoutMs:(timeoutSec*1000)]])
         logDebug"sendUPSCommand(): queued ${state.pendingCmds.size()} Telnet lines for delayed send"
         runInMillis(500,"delayedTelnetSend")
     }catch(e){
@@ -443,7 +453,12 @@ private void watchdog(){
    Command Helpers
    =============================== */
 private checkSessionTimeout(Map data){
-    def cmd=data?.cmd?:'Unknown';def timeoutMs=(data?.timeoutMs?:10000) as Long;def start=getTransient("sessionStart")?:0L;def elapsed=now()-start;def s=device.currentValue("connectStatus")
+    def cmd=data?.cmd?:'Unknown';def token=(data?.token?:'') as String;def timeoutMs=(data?.timeoutMs?:10000) as Long;def start=getTransient("sessionStart")?:0L;def elapsed=now()-start;def s=device.currentValue("connectStatus")
+    Map inFlight=getInFlightCommand();String activeToken=((inFlight?.token?:'') as String)
+    if(token&&activeToken&&token!=activeToken){
+        logDebug"checkSessionTimeout(): stale timer ignored for ${cmd}"
+        return
+    }
     if(s!="Disconnected"&&elapsed>timeoutMs){
         logWarn"checkSessionTimeout(): ${cmd} still ${s} after ${elapsed}ms — forcing cleanup"
         emitChangedEvent("lastCommandResult","Failed","${cmd} watchdog-triggered recovery")
@@ -549,12 +564,20 @@ def refresh() {
    Session Finalization
    =============================== */
 private finalizeSession(String origin){
+    Map inFlight=getInFlightCommand()
+    String token=((getTransient("sessionToken")?:inFlight?.token?:"") as String)
+    if(token&&getTransient("sessionFinalizedToken")==token){
+        logDebug"finalizeSession(): duplicate finalize suppressed from ${origin}"
+        return
+    }
+    if(token)setTransient("sessionFinalizedToken",token)
     def f=getTransient("finalizing");if(f&&f!=origin){logDebug"finalizeSession(): already running from ${f}, skipping duplicate (${origin})";return}
     setTransient("finalizing",origin)
     try{
         if(getTransient("sessionStart"))emitLastUpdate()
         def cmd=(getTransient("currentCommand")?:atomicState.lastCommand?:"Session")
-        emitChangedEvent("lastCommandResult","Complete","${cmd} completed normally")
+        def currentResult=device.currentValue("lastCommandResult")
+        if(currentResult in [null,"","Pending"])emitChangedEvent("lastCommandResult","Complete","${cmd} completed normally")
         logDebug"finalizeSession(): cleanup from ${origin}"
         switch(cmd.toLowerCase()){
             case"self test":try{runIn(45,"refresh")}catch(e){};break
@@ -770,6 +793,14 @@ private List<String> extractSection(List<Map> lines,String start,String end){def
 private void processBufferedSession(){
     def buf=getTransient("telnetBuffer")?:[]
     if(!buf)return
+    Map inFlight=getInFlightCommand()
+    String token=((getTransient("sessionToken")?:inFlight?.token?:"") as String)
+    if(token&&getTransient("sessionProcessedToken")==token){
+        logDebug"processBufferedSession(): duplicate processing suppressed"
+        clearTransient("telnetBuffer")
+        return
+    }
+    if(token)setTransient("sessionProcessedToken",token)
     def lines=buf.findAll{it.line}
     clearTransient("telnetBuffer")
     def secBanner=extractSection(lines,"Schneider","apc>")
@@ -794,6 +825,14 @@ private void processUPSCommand(){
     if(!buf||buf.isEmpty()){
         logDebug "processUPSCommand(): No buffered data to process";return
     }
+    Map inFlight=getInFlightCommand()
+    String token=((getTransient("sessionToken")?:inFlight?.token?:"") as String)
+    if(token&&getTransient("sessionProcessedToken")==token){
+        logDebug "processUPSCommand(): duplicate processing suppressed"
+        clearTransient("telnetBuffer")
+        return
+    }
+    if(token)setTransient("sessionProcessedToken",token)
     def lines=buf.findAll {it.line}.collect {it.line.trim()}
     clearTransient("telnetBuffer");def cmd=atomicState.lastCommand?:"Unknown"
     logDebug "processUPSCommand(): processing ${lines.size()} lines for UPS command '${cmd}'"
@@ -911,7 +950,12 @@ private void closeConnection(){
         def b=getTransient("telnetBuffer")?:[]
         def activeCmd=(atomicState.lastCommand?:"") as String
         if(b&&b.size()>0&&activeCmd){
-            if(activeCmd=="Reconnoiter")processBufferedSession()else processUPSCommand()
+            Map inFlight=getInFlightCommand()
+            String token=((getTransient("sessionToken")?:inFlight?.token?:"") as String)
+            if(token&&getTransient("sessionProcessedToken")==token){
+                logDebug"closeConnection(): buffer already processed for active session"
+                clearTransient("telnetBuffer")
+            }else if(activeCmd=="Reconnoiter")processBufferedSession()else processUPSCommand()
         }else if(b&&b.size()>0&&!activeCmd){
             logDebug"closeConnection(): dropping buffered data with no active command context"
         }else logDebug"closeConnection(): no buffered data"

--- a/Drivers/APC-SmartUPS/APC-SmartUPS-Status.groovy
+++ b/Drivers/APC-SmartUPS/APC-SmartUPS-Status.groovy
@@ -36,6 +36,7 @@
 *               requeue/execute, and treat empty deferred payload callback as debug no-op.
 *  1.0.4.3   -- Increased Reconnoiter session watchdog window to 15s (commands remain 10s) to account for startup pacing under slower APC/NMC response conditions.
 *  1.0.4.4   -- Arbiter stability pass: restored queue/in-flight persistence to state and added session-token guards to suppress duplicate processing/finalization.
+*  1.0.4.5   -- Queue/parse race fix: age-gated in-flight stale clearing to avoid premature handoff during disconnect transitions, and E-code-only UPS command result parsing.
 */
 
 import groovy.transform.Field
@@ -43,7 +44,7 @@ import java.util.Collections
 import java.util.UUID
 
 @Field static final String DRIVER_NAME     = "APC SmartUPS Status"
-@Field static final String DRIVER_VERSION  = "1.0.4.4"
+@Field static final String DRIVER_VERSION  = "1.0.4.5"
 @Field static final String DRIVER_MODIFIED = "2026.02.28"
 @Field static final Map transientContext   = Collections.synchronizedMap([:])
 
@@ -350,6 +351,14 @@ def processCommandQueue(){
         }
         long started=((inFlight.startedAt?:0L) as Long)
         long ageMs=started>0?(now()-started):-1L
+        String inFlightCmd=((inFlight.cmd?:"") as String)
+        long staleThresholdMs=(inFlightCmd=="Reconnoiter")?30000L:15000L
+        if(ageMs>=0L&&ageMs<staleThresholdMs){
+            logDebug"processCommandQueue(): waiting on in-flight '${inFlightCmd?:'Unknown'}' while ${cs?:'n/a'} (age=${ageMs}ms < ${staleThresholdMs}ms)"
+            unschedule("processCommandQueue")
+            runIn(1,"processCommandQueue")
+            return
+        }
         logWarn"processCommandQueue(): clearing stale in-flight '${inFlight.cmd?:'Unknown'}' while ${cs?:'n/a'} (age=${ageMs}ms)"
         clearInFlightCommand()
     }
@@ -677,6 +686,7 @@ private handleIdentificationAndSelfTest(def pair){
 
 private handleUPSCommands(def pair){
     if(!pair) return;def code=pair[0]?.trim(),desc=translateUPSError(code),cmd=atomicState.lastCommand
+    if(!(code==~ /^E\d{3}:$/))return
     def validCmds=["Alarm Test","Self Test","UPS On","UPS Off","Reboot","Sleep","Calibrate Run Time","setOutletGroup"]
     if(!(cmd in validCmds))return
     if(code in["E000:","E001:"]){emitChangedEvent("lastCommandResult","Success","Command '${cmd}' acknowledged by UPS (${desc})");logInfo"UPS Command '${cmd}' succeeded (${desc})";return}

--- a/Drivers/APC-SmartUPS/APC-SmartUPS-Status.groovy
+++ b/Drivers/APC-SmartUPS/APC-SmartUPS-Status.groovy
@@ -37,6 +37,7 @@
 *  1.0.4.3   -- Increased Reconnoiter session watchdog window to 15s (commands remain 10s) to account for startup pacing under slower APC/NMC response conditions.
 *  1.0.4.4   -- Arbiter stability pass: restored queue/in-flight persistence to state and added session-token guards to suppress duplicate processing/finalization.
 *  1.0.4.5   -- Queue/parse race fix: age-gated in-flight stale clearing to avoid premature handoff during disconnect transitions, and E-code-only UPS command result parsing.
+*  1.0.4.6   -- Finalization reliability pass: removed fragile cross-origin finalize gate and guaranteed finalize cleanup via try/finally in both command-processing paths.
 */
 
 import groovy.transform.Field
@@ -44,7 +45,7 @@ import java.util.Collections
 import java.util.UUID
 
 @Field static final String DRIVER_NAME     = "APC SmartUPS Status"
-@Field static final String DRIVER_VERSION  = "1.0.4.5"
+@Field static final String DRIVER_VERSION  = "1.0.4.6"
 @Field static final String DRIVER_MODIFIED = "2026.02.28"
 @Field static final Map transientContext   = Collections.synchronizedMap([:])
 
@@ -580,8 +581,6 @@ private finalizeSession(String origin){
         return
     }
     if(token)setTransient("sessionFinalizedToken",token)
-    def f=getTransient("finalizing");if(f&&f!=origin){logDebug"finalizeSession(): already running from ${f}, skipping duplicate (${origin})";return}
-    setTransient("finalizing",origin)
     try{
         if(getTransient("sessionStart"))emitLastUpdate()
         def cmd=(getTransient("currentCommand")?:atomicState.lastCommand?:"Session")
@@ -595,7 +594,7 @@ private finalizeSession(String origin){
         }
     }catch(e){logWarn"finalizeSession(): ${e.message}"}finally{
         clearInFlightCommand()
-        resetTransientState("finalizeSession",true);clearTransient("finalizing")
+        resetTransientState("finalizeSession",true)
         runInMillis(100,"processCommandQueue")
     }
 }
@@ -811,23 +810,26 @@ private void processBufferedSession(){
         return
     }
     if(token)setTransient("sessionProcessedToken",token)
-    def lines=buf.findAll{it.line}
-    clearTransient("telnetBuffer")
-    def secBanner=extractSection(lines,"Schneider","apc>")
-    def secUps=extractSection(lines,"apc>ups ?","apc>")
-    def secAbout=extractSection(lines,"apc>about","apc>")
-    def secUpsAbout=extractSection(lines,"apc>upsabout","apc>")
-    def secAlarmCrit=extractSection(lines,"apc>alarmcount -p critical","apc>")
-    def secAlarmWarn=extractSection(lines,"apc>alarmcount -p warning","apc>")
-    def secAlarmInfo=extractSection(lines,"apc>alarmcount -p informational","apc>")
-    def secDetStatus=extractSection(lines,"apc>detstatus -all","apc>")
-    if(secBanner)handleBannerSection(secBanner)
-    if(secUps)handleUPSSection(secUps)
-    if(secUpsAbout)handleUPSAboutSection(secUpsAbout)
-    if(secAbout)handleNMCData(secAbout)
-    if(secAlarmCrit||secAlarmWarn||secAlarmInfo)handleAlarmCount(secAlarmCrit+secAlarmWarn+secAlarmInfo)
-    if(secDetStatus)handleDetStatus(secDetStatus)
-    finalizeSession("processBufferedSession")
+    try{
+        def lines=buf.findAll{it.line}
+        clearTransient("telnetBuffer")
+        def secBanner=extractSection(lines,"Schneider","apc>")
+        def secUps=extractSection(lines,"apc>ups ?","apc>")
+        def secAbout=extractSection(lines,"apc>about","apc>")
+        def secUpsAbout=extractSection(lines,"apc>upsabout","apc>")
+        def secAlarmCrit=extractSection(lines,"apc>alarmcount -p critical","apc>")
+        def secAlarmWarn=extractSection(lines,"apc>alarmcount -p warning","apc>")
+        def secAlarmInfo=extractSection(lines,"apc>alarmcount -p informational","apc>")
+        def secDetStatus=extractSection(lines,"apc>detstatus -all","apc>")
+        if(secBanner)handleBannerSection(secBanner)
+        if(secUps)handleUPSSection(secUps)
+        if(secUpsAbout)handleUPSAboutSection(secUpsAbout)
+        if(secAbout)handleNMCData(secAbout)
+        if(secAlarmCrit||secAlarmWarn||secAlarmInfo)handleAlarmCount(secAlarmCrit+secAlarmWarn+secAlarmInfo)
+        if(secDetStatus)handleDetStatus(secDetStatus)
+    }finally{
+        finalizeSession("processBufferedSession")
+    }
 }
 
 private void processUPSCommand(){
@@ -843,18 +845,21 @@ private void processUPSCommand(){
         return
     }
     if(token)setTransient("sessionProcessedToken",token)
-    def lines=buf.findAll {it.line}.collect {it.line.trim()}
-    clearTransient("telnetBuffer");def cmd=atomicState.lastCommand?:"Unknown"
-    logDebug "processUPSCommand(): processing ${lines.size()} lines for UPS command '${cmd}'"
-    def errLine=lines.find { it ==~ /^E\\d{3}:/ }
-    if(errLine){
-        logInfo "processUPSCommand(): UPS command '${cmd}' returned '${errLine}'"
-        handleUPSCommands(errLine.split(/\s+/))
-    }else{
-        logWarn"processUPSCommand(): UPS command '${cmd}' completed with no E-code response"
-        emitChangedEvent("lastCommandResult","No Response","Command '${cmd}' completed without explicit result")
+    try{
+        def lines=buf.findAll {it.line}.collect {it.line.trim()}
+        clearTransient("telnetBuffer");def cmd=atomicState.lastCommand?:"Unknown"
+        logDebug "processUPSCommand(): processing ${lines.size()} lines for UPS command '${cmd}'"
+        def errLine=lines.find { it ==~ /^E\\d{3}:/ }
+        if(errLine){
+            logInfo "processUPSCommand(): UPS command '${cmd}' returned '${errLine}'"
+            handleUPSCommands(errLine.split(/\s+/))
+        }else{
+            logWarn"processUPSCommand(): UPS command '${cmd}' completed with no E-code response"
+            emitChangedEvent("lastCommandResult","No Response","Command '${cmd}' completed without explicit result")
+        }
+    }finally{
+        finalizeSession("processUPSCommand")
     }
-    finalizeSession("processUPSCommand")
 }
 
 private void sendHubShutdown(){
@@ -974,7 +979,7 @@ private void closeConnection(){
         if(cs!="Disconnected"&&cs!="Disconnecting"){
             updateConnectState("Disconnected")
         }else logDebug"closeConnection(): connectStatus already ${cs}"
-        clearTransient("telnetBuffer");clearTransient("rxCarry");clearTransient("sendThrottleRemaining");clearTransient("sendThrottleMs");clearTransient("finalizing")
+        clearTransient("telnetBuffer");clearTransient("rxCarry");clearTransient("sendThrottleRemaining");clearTransient("sendThrottleMs")
         clearTransient("sessionStart");clearTransient("currentCommand")
         clearInFlightCommand()
         runInMillis(100,"processCommandQueue")

--- a/Drivers/APC-SmartUPS/spec/CONFORMANCE_CHECKLIST.md
+++ b/Drivers/APC-SmartUPS/spec/CONFORMANCE_CHECKLIST.md
@@ -1,0 +1,59 @@
+# APC SmartUPS Clean-Room Conformance Checklist
+
+Use this checklist to validate any fresh implementation against the behavior contract in `MODULE_SPEC.md` and vectors in `TEST_VECTORS.json`.
+
+## A) Interface and Environment
+- [ ] Implementation language/runtime is Hubitat-compatible Groovy.
+- [ ] All required commands are exposed.
+- [ ] Required preferences are supported with expected ranges/defaults.
+- [ ] Required attributes are emitted with compatible naming and types.
+
+## B) Queue/In-Flight Arbiter
+- [ ] Exactly one command can be in-flight at any time.
+- [ ] Pending commands are FIFO.
+- [ ] Reconnoiter dedupe prevents multiple queued/in-flight recon sessions.
+- [ ] Queue pump reschedules while active session is in progress.
+
+## C) Session Lifecycle Correctness
+- [ ] Each session has unique token.
+- [ ] Session marks `Pending` at start.
+- [ ] Session processing runs at most once per token.
+- [ ] Finalization runs at most once per token.
+- [ ] Finalization always clears in-flight and pumps queue.
+
+## D) Result Semantics
+- [ ] E000/E001 produce `Success`.
+- [ ] E1xx produce `Failure` with mapped explanation.
+- [ ] Non-E-code telemetry lines never produce command failure.
+- [ ] Missing E-code yields `No Response`.
+- [ ] `Complete` fallback only occurs if result remains `Pending`.
+- [ ] No duplicate terminal result events for one token.
+
+## E) Race/Recovery Robustness
+- [ ] Stale timer callbacks are ignored by token mismatch.
+- [ ] Duplicate close/status callbacks do not replay processing.
+- [ ] In-flight stale clear uses age thresholds (not immediate disconnect clear).
+- [ ] Recovery path returns to clean `Disconnected` baseline.
+
+## F) Parse/Normalization
+- [ ] Inbound parser normalizes CR/LF/NUL correctly.
+- [ ] Partial line carry across chunks works.
+- [ ] Carry size is bounded.
+
+## G) Overlap Scenario (Critical)
+- [ ] Canonical overlap passes: alarm → refresh → alarm during refresh → alarm after refresh.
+- [ ] Alarm queued during refresh is executed (not lost, not silently dropped).
+- [ ] Post-run queue depth returns to zero.
+- [ ] No ghost in-flight remains after completion.
+
+## H) Operational Safety
+- [ ] Control commands are blocked while UPS control disabled.
+- [ ] Reconnoiter remains allowed when control disabled.
+- [ ] Follow-up refresh delays for self-test/reboot/UPS on/off are honored.
+- [ ] Low battery handling is edge-triggered and idempotent.
+
+## I) Evidence Required for Sign-off
+- [ ] Test harness output proving pass of all vectors in `TEST_VECTORS.json`.
+- [ ] Event trace excerpt for canonical overlap scenario.
+- [ ] Log excerpt showing no duplicate terminal events per token.
+- [ ] Overnight stability sample showing no stale in-flight accumulation.

--- a/Drivers/APC-SmartUPS/spec/HANDOFF_INSTRUCTIONS.md
+++ b/Drivers/APC-SmartUPS/spec/HANDOFF_INSTRUCTIONS.md
@@ -1,0 +1,26 @@
+# Clean-Room Handoff Instructions
+
+Provide ONLY the files in this `spec/` folder to the implementation agent:
+- `MODULE_SPEC.md`
+- `TEST_VECTORS.json`
+- `CONFORMANCE_CHECKLIST.md`
+
+## Rules for the implementation agent
+1. Do not inspect existing APC driver implementation.
+2. Implement solely from the contract and vectors.
+3. Build a mocked Hubitat harness to execute vectors deterministically.
+4. Produce:
+   - implementation source
+   - test harness source
+   - machine-readable test report (pass/fail per vector)
+   - short variance report for any unsupported assumptions
+
+## Verification protocol
+1. Run all vectors from `TEST_VECTORS.json`.
+2. Mark checklist items in `CONFORMANCE_CHECKLIST.md`.
+3. Reject implementation if critical overlap scenario fails.
+4. If all pass, compare behavior against live UPS logs in one staged trial.
+
+## Notes
+- This process is meant to break context-carrying bugs from legacy code paths.
+- If test vectors reveal ambiguous behavior, update `MODULE_SPEC.md` first, then rerun.

--- a/Drivers/APC-SmartUPS/spec/MODULE_SPEC.md
+++ b/Drivers/APC-SmartUPS/spec/MODULE_SPEC.md
@@ -1,0 +1,165 @@
+# APC SmartUPS Hubitat Module Specification (Clean-Room Contract)
+
+## 1) Goal
+Implement a deterministic Hubitat driver module for APC Smart-UPS (NMC Telnet) that:
+- Collects telemetry via periodic reconnoiter sessions.
+- Executes control commands (alarm/self-test/power/reboot/sleep/outlet) with safety gating.
+- Enforces single in-flight command processing with FIFO queueing.
+- Produces stable, non-duplicated result events under asynchronous callback races.
+
+This specification is implementation-agnostic and intended for clean-room reimplementation.
+
+## 2) Language and Runtime Environment
+- Language: Groovy
+- Platform: Hubitat Elevation custom driver runtime
+- Network transport: Hubitat Telnet APIs (`telnetConnect`, `telnetClose`, parse callback)
+- Scheduling/timers: Hubitat scheduler APIs (`runIn`, `runInMillis`, `schedule`, `unschedule`)
+- Event model: Hubitat device attributes via `sendEvent`
+
+## 3) External Inputs
+### 3.1 Preferences (configuration)
+- `upsIP` (string, required)
+- `upsPort` (int, default 23)
+- `Username` (string, required)
+- `Password` (string, required)
+- `runTime` (int 1..59)
+- `runOffset` (int 0..59)
+- `runTimeOnBattery` (int 1..59)
+- `autoShutdownHub` (bool)
+- `upsTZOffset` (int -720..840)
+- `useUpsNameForLabel` (bool)
+- `tempUnits` (`F`|`C`)
+- `logEnable`, `logEvents`, `logCallbackTrace` (bool)
+
+### 3.2 Commands (API entry points)
+- `refresh`
+- `alarmTest`
+- `selfTest`
+- `upsOn`
+- `upsOff`
+- `reboot`
+- `sleep`
+- `toggleRunTimeCalibration`
+- `setOutletGroup(outletGroup, command, seconds)`
+- `enableUPSControl`
+- `disableUPSControl`
+
+### 3.3 Transport inputs
+- Telnet text chunks delivered to `parse(String msg)`.
+- Telnet status callbacks (`telnetStatus(String s)`).
+
+## 4) External Outputs
+### 4.1 Required attributes/events
+- Connection/session: `connectStatus`, `lastUpdate`, `lastCommand`, `lastCommandResult`
+- UPS state: `upsStatus`, `lastTransferCause`, `battery`, `batteryVoltage`, `runTimeHours`, `runTimeMinutes`, `lowBattery`
+- Electrical: `inputVoltage`, `inputFrequency`, `outputVoltage`, `outputFrequency`, `outputCurrent`, `outputWatts`, `outputWattsPercent`, `outputVAPercent`, `outputEnergy`
+- Device identity: `model`, `serialNumber`, `firmwareVersion`, `manufactureDate`
+- NMC identity/status: `nmcModel`, `nmcSerialNumber`, `nmcHardwareRevision`, `nmcApplicationName`, `nmcApplicationVersion`, `nmcApplicationDate`, `nmcOSName`, `nmcOSVersion`, `nmcOSDate`, `nmcBootMonitor`, `nmcBootMonitorVersion`, `nmcBootMonitorDate`, `nmcMACAddress`, `nmcUptime`, `nmcStatus`, `nmcStatusDesc`
+- Misc: `temperature`, `temperatureF`, `temperatureC`, `upsUptime`, `upsDateTime`, `upsContact`, `upsLocation`, `alarmCountCrit`, `alarmCountWarn`, `alarmCountInfo`, `summaryText`, `wiringFault`, `nextBatteryReplacement`
+
+### 4.2 Command result semantics
+For control commands, `lastCommandResult` must follow one of:
+- `Pending` at queue acceptance for execution.
+- `Success` when an explicit E-code success (`E000:`/`E001:`) is received.
+- `Failure` for explicit E-code failures (`E1xx:` with mapped message).
+- `No Response` if command session completes without any E-code.
+- `Complete` only as fallback when still `Pending` at finalize and no explicit result set.
+
+## 5) Core Behavioral Requirements
+### 5.1 Queue and in-flight arbiter
+- Exactly one in-flight command session at a time.
+- FIFO queue for pending commands.
+- Reconnoiter dedupe: at most one queued/in-flight `Reconnoiter` at a time.
+- Optional priority rule: non-recon commands may be inserted ahead of queued recon (to avoid starvation of user actions).
+
+### 5.2 Session lifecycle (deterministic)
+For each dequeued command:
+1. Create session token (unique ID).
+2. Set in-flight (`cmd`, `startedAt`, `token`).
+3. Emit `Pending`.
+4. Open telnet connection.
+5. Send username/password + command lines + `whoami` terminator.
+6. Buffer parse lines until terminal condition (`whoami` sequence complete or connection close fallback).
+7. Process buffered payload exactly once per token.
+8. Finalize exactly once per token.
+9. Clear in-flight and transient session context.
+10. Pump queue.
+
+### 5.3 Idempotency and race safety
+- Processing and finalization must be token-idempotent.
+- Stale callbacks/timers from prior sessions must be ignored by token mismatch.
+- Duplicate close/status callbacks must not replay parsing or result emission for same token.
+
+### 5.4 Stale in-flight handling
+- Only clear in-flight as stale when age threshold exceeded.
+- Thresholds (recommended):
+  - control commands: 15,000 ms
+  - reconnoiter: 30,000 ms
+- If in-flight age < threshold and command not finished, queue pump must reschedule, not clear.
+
+### 5.5 Parse normalization
+- Normalize line endings: CRLF/CR/NUL to LF stream.
+- Preserve partial carry across chunks.
+- Bound carry size to prevent memory growth.
+- Only evaluate command-result E-codes from lines matching `^E\d{3}:`.
+
+### 5.6 Safety gate for control commands
+- If control command invoked while UPS control disabled:
+  - do not queue command
+  - emit warning log
+  - no session side effects
+- `Reconnoiter` remains allowed regardless of control gate.
+
+### 5.7 Follow-up refresh rules
+On finalize for command:
+- `Self Test` => schedule `refresh` at +45s
+- `Reboot` => schedule `refresh` at +90s
+- `UPS On`/`UPS Off` => schedule `refresh` at +30s
+
+### 5.8 Low battery automation
+- Compute low battery threshold as `2 * runTimeOnBattery` minutes.
+- Emit `lowBattery` transitions.
+- If low battery and `autoShutdownHub=true`, issue local hub shutdown once per low-battery episode.
+
+## 6) State Model
+### 6.1 Persistent state (required)
+- Queue (`commandQueue`)
+- In-flight (`commandInFlight`)
+- Long-lived settings/support flags (`upsControlEnabled`, outlet support, scheduler markers)
+
+### 6.2 Transient/session state (required)
+- `sessionToken`, `sessionStart`, `currentCommand`
+- `sessionProcessedToken`, `sessionFinalizedToken`
+- `telnetBuffer`, `rxCarry`
+- auth markers for whoami completion
+
+## 7) Logging Contract (minimum)
+Must provide log lines enabling postmortem of queue/session behavior:
+- enqueue with depth
+- dequeue with cmd
+- command execution start
+- command result source (`E-code` / `No Response` / fallback complete)
+- stale clear with age and cmd
+- token-mismatch stale-callback ignore notices (debug)
+
+## 8) Non-Functional Requirements
+- No blocking loops for transport waits; all waits scheduler-driven.
+- Bounded memory behavior for parse carry/buffers.
+- Recovery from stream close/errors returns to clean `Disconnected` baseline.
+- Repeated refresh intervals (overnight) must not accumulate ghost in-flight state.
+
+## 9) Explicitly Forbidden Behaviors
+- Multiple commands concurrently in flight.
+- Emitting command failure based on non-E-code telemetry lines.
+- Reprocessing same session payload due to duplicate callbacks.
+- Clearing in-flight immediately on every disconnect transition regardless of age.
+
+## 10) Acceptance Criteria (high level)
+- All conformance checks in `spec/CONFORMANCE_CHECKLIST.md` pass.
+- All deterministic scenarios in `spec/TEST_VECTORS.json` produce expected state/event traces.
+- No duplicate terminal result emissions for a single session token.
+- No lost queued command in the canonical overlap scenario:
+  1) alarm
+  2) refresh
+  3) alarm during refresh
+  4) alarm after refresh

--- a/Drivers/APC-SmartUPS/spec/TEST_VECTORS.json
+++ b/Drivers/APC-SmartUPS/spec/TEST_VECTORS.json
@@ -1,0 +1,209 @@
+{
+  "version": "1.0.0",
+  "module": "APC SmartUPS Hubitat Driver",
+  "description": "Deterministic clean-room test vectors for queue/session/parser behavior. These vectors are implementation-agnostic and should be executed in a mocked Hubitat runtime harness.",
+  "assumptions": {
+    "clockUnit": "ms",
+    "controlEnabledDefault": false,
+    "staleThresholdMs": {
+      "defaultCommand": 15000,
+      "reconnoiter": 30000
+    }
+  },
+  "vectors": [
+    {
+      "id": "TV-001-control-gate",
+      "title": "Control command rejected while UPS control disabled",
+      "setup": {
+        "state": { "upsControlEnabled": false, "commandQueue": [], "commandInFlight": null },
+        "attributes": { "connectStatus": "Disconnected" }
+      },
+      "stimulus": [
+        { "t": 0, "type": "command", "name": "alarmTest" }
+      ],
+      "expect": {
+        "queueDepth": 0,
+        "inFlight": null,
+        "events": [],
+        "logsContains": ["Alarm Test called but UPS control is disabled"]
+      }
+    },
+    {
+      "id": "TV-002-basic-alarm-success",
+      "title": "Single Alarm Test success path",
+      "setup": {
+        "state": { "upsControlEnabled": true, "commandQueue": [], "commandInFlight": null },
+        "attributes": { "connectStatus": "Disconnected" }
+      },
+      "stimulus": [
+        { "t": 0, "type": "command", "name": "alarmTest" },
+        { "t": 50, "type": "parse", "chunk": "apc>whoami\n" },
+        { "t": 60, "type": "parse", "chunk": "E000: Success\n" },
+        { "t": 70, "type": "parse", "chunk": "username\n" }
+      ],
+      "expect": {
+        "eventsOrdered": [
+          "lastCommandResult=Pending",
+          "lastCommandResult=Success"
+        ],
+        "terminalResultOneOf": ["Success", "Complete"],
+        "maxTerminalResultEmits": 1,
+        "queueDepth": 0,
+        "inFlight": null
+      }
+    },
+    {
+      "id": "TV-003-no-response-fallback",
+      "title": "No E-code yields No Response",
+      "setup": {
+        "state": { "upsControlEnabled": true, "commandQueue": [], "commandInFlight": null },
+        "attributes": { "connectStatus": "Disconnected" }
+      },
+      "stimulus": [
+        { "t": 0, "type": "command", "name": "alarmTest" },
+        { "t": 50, "type": "parse", "chunk": "apc>whoami\n" },
+        { "t": 60, "type": "parse", "chunk": "some telemetry line\n" },
+        { "t": 70, "type": "parse", "chunk": "username\n" }
+      ],
+      "expect": {
+        "eventsOrdered": [
+          "lastCommandResult=Pending",
+          "lastCommandResult=No Response"
+        ],
+        "queueDepth": 0,
+        "inFlight": null
+      }
+    },
+    {
+      "id": "TV-004-ignore-non-ecode-as-command-failure",
+      "title": "Telemetry tokens do not produce command failure",
+      "setup": {
+        "state": { "upsControlEnabled": true },
+        "attributes": { "lastCommand": "Alarm Test" }
+      },
+      "stimulus": [
+        { "t": 0, "type": "direct", "fn": "handleUPSCommands", "args": [["Output", "Voltage:", "120.0"]] },
+        { "t": 1, "type": "direct", "fn": "handleUPSCommands", "args": [["Battery", "State", "Of", "Charge:", "98"]] }
+      ],
+      "expect": {
+        "events": [],
+        "logsNotContains": ["UPS Command 'Alarm Test' failed"]
+      }
+    },
+    {
+      "id": "TV-005-overlap-canonical",
+      "title": "Canonical overlap: alarm during refresh must execute",
+      "setup": {
+        "state": { "upsControlEnabled": true, "commandQueue": [], "commandInFlight": null },
+        "attributes": { "connectStatus": "Disconnected" }
+      },
+      "stimulus": [
+        { "t": 0, "type": "command", "name": "alarmTest" },
+        { "t": 2000, "type": "command", "name": "refresh" },
+        { "t": 2500, "type": "command", "name": "alarmTest" },
+        { "t": 5000, "type": "parse", "chunk": "apc>whoami\nE000: Success\nusername\n" },
+        { "t": 9000, "type": "parse", "chunk": "Schneider\napc>ups ?\n...\napc>whoami\nE000: Success\nusername\n" },
+        { "t": 13000, "type": "parse", "chunk": "apc>whoami\nE000: Success\nusername\n" }
+      ],
+      "expect": {
+        "minAlarmExecutions": 2,
+        "noLostQueuedAlarm": true,
+        "queueDepth": 0,
+        "inFlight": null,
+        "logsOrderedContains": [
+          "Alarm Test queued",
+          "processCommandQueue(): dequeued 'Alarm Test'",
+          "Executing UPS command: Alarm Test",
+          "Reconnoiter",
+          "Alarm Test queued",
+          "processCommandQueue(): dequeued 'Alarm Test'"
+        ]
+      }
+    },
+    {
+      "id": "TV-006-duplicate-close-callback",
+      "title": "Duplicate close/status callbacks do not duplicate terminal events",
+      "setup": {
+        "state": { "upsControlEnabled": true },
+        "attributes": { "connectStatus": "Connected" }
+      },
+      "stimulus": [
+        { "t": 0, "type": "command", "name": "alarmTest" },
+        { "t": 100, "type": "parse", "chunk": "apc>whoami\nE000: Success\nusername\n" },
+        { "t": 110, "type": "status", "value": "receive error: Stream is closed" },
+        { "t": 120, "type": "status", "value": "receive error: Stream is closed" }
+      ],
+      "expect": {
+        "maxTerminalResultEmits": 1,
+        "queueDepth": 0,
+        "inFlight": null
+      }
+    },
+    {
+      "id": "TV-007-stale-timer-ignored",
+      "title": "Old watchdog timer does not clear newer in-flight command",
+      "setup": {
+        "state": { "upsControlEnabled": true },
+        "attributes": { "connectStatus": "Connected" }
+      },
+      "stimulus": [
+        { "t": 0, "type": "command", "name": "alarmTest" },
+        { "t": 500, "type": "command", "name": "alarmTest" },
+        { "t": 10000, "type": "timer", "name": "checkSessionTimeout", "data": { "cmd": "Alarm Test", "token": "OLD_TOKEN", "timeoutMs": 10000 } }
+      ],
+      "expect": {
+        "logsContains": ["stale timer ignored"],
+        "doesNotClearActiveInFlightByOldToken": true
+      }
+    },
+    {
+      "id": "TV-008-stale-clear-threshold",
+      "title": "In-flight not cleared before stale threshold",
+      "setup": {
+        "state": { "upsControlEnabled": true, "commandInFlight": { "cmd": "Alarm Test", "startedAt": 0, "token": "T1" } },
+        "attributes": { "connectStatus": "Disconnected" }
+      },
+      "stimulus": [
+        { "t": 5000, "type": "invoke", "fn": "processCommandQueue" },
+        { "t": 14999, "type": "invoke", "fn": "processCommandQueue" },
+        { "t": 15001, "type": "invoke", "fn": "processCommandQueue" }
+      ],
+      "expect": {
+        "beforeThreshold": { "inFlightStillSet": true },
+        "afterThreshold": { "inFlightCleared": true }
+      }
+    },
+    {
+      "id": "TV-009-recon-dedupe",
+      "title": "Multiple refresh calls coalesce to one recon request",
+      "setup": {
+        "state": { "upsControlEnabled": true, "commandQueue": [] },
+        "attributes": { "connectStatus": "Disconnected" }
+      },
+      "stimulus": [
+        { "t": 0, "type": "command", "name": "refresh" },
+        { "t": 1, "type": "command", "name": "refresh" },
+        { "t": 2, "type": "command", "name": "refresh" }
+      ],
+      "expect": {
+        "maxQueuedRecon": 1
+      }
+    },
+    {
+      "id": "TV-010-normalizer-crlf-cr-nul",
+      "title": "Inbound normalizer handles CR/LF/NUL framing",
+      "setup": {
+        "state": {},
+        "attributes": {}
+      },
+      "stimulus": [
+        { "t": 0, "type": "parse", "chunk": "line1\r\nline2\u0000\rline3\npartial" },
+        { "t": 1, "type": "parse", "chunk": "-cont\n" }
+      ],
+      "expect": {
+        "normalizedLinesContain": ["line1", "line2", "line3", "partial-cont"],
+        "noNulInNormalizedLines": true
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Strategy Reset\nThis supersedes prior transport/auth experiments with a clean baseline branch.\n\n## Scope (this PR only)\n- Branch from stable baseline commit 18875ba (v1.0.4.0)\n- Add one transport-layer stream normalizer in parse() path\n- Normalize CR/LF/NUL framing with carry-over support\n- Emit semantic prompt boundaries (User Name:, Password:, pc>, E###:) even without newline\n\n## Explicitly Out of Scope\n- No auth state-machine redesign\n- No timeout fallback/auth nudge logic\n- No command-path behavior refactors\n\n## Goal\nEstablish deterministic prompt visibility at the parser boundary before reintroducing any later fixes by cherry-pick if needed.\n